### PR TITLE
Feature/add canvas undo redo

### DIFF
--- a/src/components/draw/DrawingPaper.vue
+++ b/src/components/draw/DrawingPaper.vue
@@ -219,7 +219,11 @@ export default defineComponent({
         `/${getRoomId()}/`
     )
 
-    const getMessage = () => {
+    const getMessage = async () => {
+      await onMessage()
+    }
+
+    const onMessage = async () => {
       ws.onmessage = (e) => {
         let data = JSON.parse(e.data)
         if (data.message.type === 'clear') clear()
@@ -236,7 +240,6 @@ export default defineComponent({
             shadow: data.shadow,
             fill: data.fill
           })
-          console.log(path)
           canvas1.canvas?.add(path)
 
           var objects = canvas1.canvas?.getObjects()
@@ -277,8 +280,10 @@ export default defineComponent({
       }
 
       var objects = canvas1.canvas?.getObjects()
-      if (objects) canvas1.canvas?.remove(objects[objects.length - 1])
+      if (objects) waitDraw(objects, drawInstruction)
+    }
 
+    const sendDraw = async (drawInstruction: any) => {
       ws.send(
         JSON.stringify({
           message: {
@@ -287,6 +292,11 @@ export default defineComponent({
           }
         })
       )
+    }
+
+    const waitDraw = async (objects: fabric.Object[], drawInstruction: any) => {
+      await sendDraw(drawInstruction)
+      if (objects) canvas1.canvas?.remove(objects[objects.length - 1])
     }
 
     const sendClear = () => {
@@ -298,6 +308,7 @@ export default defineComponent({
         })
       )
     }
+
     const sendUndo = () => {
       ws.send(
         JSON.stringify({

--- a/src/components/draw/DrawingPaper.vue
+++ b/src/components/draw/DrawingPaper.vue
@@ -1,10 +1,10 @@
 <template>
   <div>
-    <div
-      class="order-2 order-lg-1 canvas_wrapper border"
-      ref="canvasRef"
-      @mouseover="test"
-    >
+    <div class="d-flex justify-content-around">
+      <button @click="undo">Undo</button>
+      <button @click="redo">Redo</button>
+    </div>
+    <div class="order-2 order-lg-1 canvas_wrapper border" ref="canvasRef">
       <canvas id="canvas"></canvas>
     </div>
   </div>
@@ -23,6 +23,7 @@ import {
 } from 'vue'
 import { fabric } from 'fabric'
 import { PencilCaseSetting } from '../../interface/pencilCaseSetting'
+import { Stack } from '../../model/stack'
 
 interface Canvas {
   canvas: fabric.Canvas | undefined
@@ -32,6 +33,9 @@ export default defineComponent({
   name: 'canvas',
   props: { pencilCaseSettings: Object as PropType<PencilCaseSetting> },
   setup(props) {
+    let undoStack = new Stack()
+    let redoStack = new Stack()
+
     const getRoomId = () => {
       const room = window.location.pathname.split('/')
       return room[room.length - 1]
@@ -72,9 +76,12 @@ export default defineComponent({
           canvas1.canvas.freeDrawingBrush.color =
             pencilCaseSetting.value.drawColor
         }
-      })
+        canvas1.canvas?.on('path:created', (e) => {
+          sendDrawingData(e)
+        })
 
-      connectWebsocket()
+        connectWebsocket()
+      })
     })
 
     onUpdated(() => {
@@ -107,7 +114,16 @@ export default defineComponent({
     }
 
     const clear = () => {
-      canvas1.canvas?.clear()
+      if (undoStack.peek() != null) {
+        canvas1.canvas?.clear()
+        redoStack.empty()
+
+        var objects = canvas1.canvas?.getObjects()
+        if (objects) {
+          undoStack.push(objects[objects.length - 2])
+          undoStack.push(objects[objects.length - 1])
+        }
+      }
     }
 
     const eraser = () => {
@@ -129,12 +145,72 @@ export default defineComponent({
       }
     }
 
+    const undo = () => {
+      if (undoStack.count) {
+        if (undoStack.peek() == undefined) {
+          console.log('undo Undefined')
+          for (let i = 0; i < 2; i++) {
+            redoStack.push(undoStack.peek())
+            undoStack.pop()
+          }
+
+          let iterator: Stack = undoStack
+          let temp = new Stack()
+
+          while (iterator != null) {
+            if (iterator.peek() == undefined) {
+              while (temp.peek() != null) {
+                undoStack.push(temp.pop())
+              }
+              return
+            } else {
+              let peekNode = iterator.peek()
+              if (peekNode != null) canvas1.canvas?.add(peekNode)
+              if (iterator.head != null) temp.push(iterator.pop())
+            }
+          }
+        } else {
+          for (let i = 0; i < 2; i++) {
+            let peekStack = undoStack.peek()
+            if (peekStack != null) {
+              canvas1.canvas?.remove(peekStack)
+              redoStack.push(peekStack)
+              undoStack.pop()
+            }
+          }
+        }
+      }
+    }
+
+    const redo = () => {
+      if (redoStack.count) {
+        if (redoStack.peek() == undefined) {
+          canvas1.canvas?.clear()
+          var objects = canvas1.canvas?.getObjects()
+          if (objects) {
+            redoStack.pop()
+            redoStack.pop()
+            undoStack.push(objects[objects.length - 2])
+            undoStack.push(objects[objects.length - 1])
+          }
+        } else {
+          for (let i = 0; i < 2; i++) {
+            let peekStack = redoStack.peek()
+            if (peekStack != null) {
+              canvas1.canvas?.add(peekStack)
+              undoStack.push(peekStack)
+              redoStack.pop()
+            }
+          }
+        }
+      }
+    }
+
     const test = () => {
       if (canvas1.canvas === undefined) return
       canvas1.canvas.on('mouse:over', (e) => {
         console.log('mouseover test')
       })
-      sendDrawingData()
     }
 
     const connectWebsocket = () => {
@@ -143,9 +219,10 @@ export default defineComponent({
       }
       getMessage()
     }
+
     const ws: WebSocket = new WebSocket(
       // 本番でwssになっていないバグ
-      (window.location.protocol == 'https' ? 'wss' : 'wss') +
+      (window.location.protocol == 'https:' ? 'wss' : 'ws') +
         '://' +
         process.env.VUE_APP_BACKEND_URL +
         'ws/draw' +
@@ -170,8 +247,14 @@ export default defineComponent({
           shadow: data.shadow,
           fill: data.fill
         })
-
         canvas1.canvas?.add(path)
+
+        var objects = canvas1.canvas?.getObjects()
+        if (objects) {
+          undoStack.push(objects[objects.length - 2])
+          undoStack.push(objects[objects.length - 1])
+          redoStack.empty()
+        }
       }
     }
 
@@ -190,32 +273,32 @@ export default defineComponent({
       }
     }
 
-    const sendDrawingData = () => {
-      canvas1.canvas?.on('path:created', (e: any) => {
-        console.log(e.path.path)
-        const pathCoordinates = convertCoordinate(e.path.path)
+    const sendDrawingData = (e: any) => {
+      const pathCoordinates = convertCoordinate(e.path.path)
 
-        const drawInstruction = {
-          pathCoordinates: pathCoordinates,
-          stroke: e.path.stroke,
-          strokeWidth: e.path.strokeWidth,
-          strokeLineCap: e.path.strokeLineCap,
-          strokeLineJoin: e.path.strokeLineJoin,
-          shadow: e.path.shadow,
-          fill: false
-        }
+      const drawInstruction = {
+        pathCoordinates: pathCoordinates,
+        stroke: e.path.stroke,
+        strokeWidth: e.path.strokeWidth,
+        strokeLineCap: e.path.strokeLineCap,
+        strokeLineJoin: e.path.strokeLineJoin,
+        shadow: e.path.shadow,
+        fill: false
+      }
 
-        ws.send(
-          JSON.stringify({
-            message: {
-              type: 'draw',
-              drawInstruction: drawInstruction
-            }
-          })
-        )
-      })
+      ws.send(
+        JSON.stringify({
+          message: {
+            type: 'draw',
+            drawInstruction: drawInstruction
+          }
+        })
+      )
     }
+
     return {
+      undoStack,
+      redoStack,
       pencilCaseSetting,
       colorPalette,
       canvasRef,
@@ -231,7 +314,9 @@ export default defineComponent({
       closeConnection,
       sendDrawingData,
       connectWebsocket,
-      convertCoordinate
+      convertCoordinate,
+      undo,
+      redo
     }
   }
 })

--- a/src/components/draw/DrawingPaper.vue
+++ b/src/components/draw/DrawingPaper.vue
@@ -30,11 +30,15 @@ interface Canvas {
 }
 
 export default defineComponent({
-  name: 'canvas',
-  props: { pencilCaseSettings: Object as PropType<PencilCaseSetting> },
+  name: 'drawingPaper',
+  props: {
+    pencilCaseSettings: Object as PropType<PencilCaseSetting>,
+    undoStack: Stack,
+    redoStack: Stack
+  },
   setup(props) {
-    let undoStack = new Stack()
-    let redoStack = new Stack()
+    let undoStack = toRef(props, 'undoStack')
+    let redoStack = toRef(props, 'redoStack')
 
     const getRoomId = () => {
       const room = window.location.pathname.split('/')
@@ -114,14 +118,14 @@ export default defineComponent({
     }
 
     const clear = () => {
-      if (undoStack.peek() != null) {
+      if (undoStack.value?.peek() != null) {
         canvas1.canvas?.clear()
-        redoStack.empty()
+        redoStack.value?.empty()
 
         var objects = canvas1.canvas?.getObjects()
         if (objects) {
-          undoStack.push(objects[objects.length - 2])
-          undoStack.push(objects[objects.length - 1])
+          undoStack.value.push(objects[objects.length - 2])
+          undoStack.value.push(objects[objects.length - 1])
         }
       }
     }
@@ -146,36 +150,35 @@ export default defineComponent({
     }
 
     const undo = () => {
-      if (undoStack.count) {
-        if (undoStack.peek() == undefined) {
-          console.log('undo Undefined')
+      if (undoStack.value?.count) {
+        if (undoStack.value.peek() == undefined) {
           for (let i = 0; i < 2; i++) {
-            redoStack.push(undoStack.peek())
-            undoStack.pop()
+            redoStack.value?.push(undoStack.value.peek())
+            undoStack.value.pop()
           }
 
-          let iterator: Stack = undoStack
+          let iterator = undoStack
           let temp = new Stack()
 
           while (iterator != null) {
-            if (iterator.peek() == undefined) {
+            if (iterator.value?.peek() == undefined) {
               while (temp.peek() != null) {
-                undoStack.push(temp.pop())
+                undoStack.value.push(temp.pop())
               }
               return
             } else {
-              let peekNode = iterator.peek()
+              let peekNode = iterator.value?.peek()
               if (peekNode != null) canvas1.canvas?.add(peekNode)
-              if (iterator.head != null) temp.push(iterator.pop())
+              if (iterator.value?.head != null) temp.push(iterator.value?.pop())
             }
           }
         } else {
           for (let i = 0; i < 2; i++) {
-            let peekStack = undoStack.peek()
+            let peekStack = undoStack.value.peek()
             if (peekStack != null) {
               canvas1.canvas?.remove(peekStack)
-              redoStack.push(peekStack)
-              undoStack.pop()
+              redoStack.value?.push(peekStack)
+              undoStack.value.pop()
             }
           }
         }
@@ -183,23 +186,23 @@ export default defineComponent({
     }
 
     const redo = () => {
-      if (redoStack.count) {
-        if (redoStack.peek() == undefined) {
+      if (redoStack.value?.count) {
+        if (redoStack.value.peek() == undefined) {
           canvas1.canvas?.clear()
           var objects = canvas1.canvas?.getObjects()
           if (objects) {
-            redoStack.pop()
-            redoStack.pop()
-            undoStack.push(objects[objects.length - 2])
-            undoStack.push(objects[objects.length - 1])
+            redoStack.value.pop()
+            redoStack.value.pop()
+            undoStack.value?.push(objects[objects.length - 2])
+            undoStack.value?.push(objects[objects.length - 1])
           }
         } else {
           for (let i = 0; i < 2; i++) {
-            let peekStack = redoStack.peek()
+            let peekStack = redoStack.value.peek()
             if (peekStack != null) {
               canvas1.canvas?.add(peekStack)
-              undoStack.push(peekStack)
-              redoStack.pop()
+              undoStack.value?.push(peekStack)
+              redoStack.value.pop()
             }
           }
         }
@@ -251,9 +254,9 @@ export default defineComponent({
 
         var objects = canvas1.canvas?.getObjects()
         if (objects) {
-          undoStack.push(objects[objects.length - 2])
-          undoStack.push(objects[objects.length - 1])
-          redoStack.empty()
+          undoStack.value?.push(objects[objects.length - 2])
+          undoStack.value?.push(objects[objects.length - 1])
+          redoStack.value?.empty()
         }
       }
     }
@@ -297,8 +300,6 @@ export default defineComponent({
     }
 
     return {
-      undoStack,
-      redoStack,
       pencilCaseSetting,
       colorPalette,
       canvasRef,

--- a/src/components/draw/DrawingPaper.vue
+++ b/src/components/draw/DrawingPaper.vue
@@ -120,7 +120,6 @@ export default defineComponent({
 
         var objects = canvas1.canvas?.getObjects()
         if (objects) {
-          undoStack.value.push(objects[objects.length - 2])
           undoStack.value.push(objects[objects.length - 1])
         }
       }
@@ -148,10 +147,8 @@ export default defineComponent({
     const undo = () => {
       if (undoStack.value?.count) {
         if (undoStack.value.peek() == undefined) {
-          for (let i = 0; i < 2; i++) {
-            redoStack.value?.push(undoStack.value.peek())
-            undoStack.value.pop()
-          }
+          redoStack.value?.push(undoStack.value.peek())
+          undoStack.value.pop()
 
           let iterator = undoStack
           let temp = new Stack()
@@ -169,13 +166,11 @@ export default defineComponent({
             }
           }
         } else {
-          for (let i = 0; i < 2; i++) {
-            let peekStack = undoStack.value.peek()
-            if (peekStack != null) {
-              canvas1.canvas?.remove(peekStack)
-              redoStack.value?.push(peekStack)
-              undoStack.value.pop()
-            }
+          let peekStack = undoStack.value.peek()
+          if (peekStack != null) {
+            canvas1.canvas?.remove(peekStack)
+            redoStack.value?.push(peekStack)
+            undoStack.value.pop()
           }
         }
       }
@@ -188,18 +183,14 @@ export default defineComponent({
           var objects = canvas1.canvas?.getObjects()
           if (objects) {
             redoStack.value.pop()
-            redoStack.value.pop()
-            undoStack.value?.push(objects[objects.length - 2])
             undoStack.value?.push(objects[objects.length - 1])
           }
         } else {
-          for (let i = 0; i < 2; i++) {
-            let peekStack = redoStack.value.peek()
-            if (peekStack != null) {
-              canvas1.canvas?.add(peekStack)
-              undoStack.value?.push(peekStack)
-              redoStack.value.pop()
-            }
+          let peekStack = redoStack.value.peek()
+          if (peekStack != null) {
+            canvas1.canvas?.add(peekStack)
+            undoStack.value?.push(peekStack)
+            redoStack.value.pop()
           }
         }
       }
@@ -245,11 +236,11 @@ export default defineComponent({
             shadow: data.shadow,
             fill: data.fill
           })
+          console.log(path)
           canvas1.canvas?.add(path)
 
           var objects = canvas1.canvas?.getObjects()
           if (objects) {
-            undoStack.value?.push(objects[objects.length - 2])
             undoStack.value?.push(objects[objects.length - 1])
             redoStack.value?.empty()
           }
@@ -284,6 +275,9 @@ export default defineComponent({
         shadow: e.path.shadow,
         fill: false
       }
+
+      var objects = canvas1.canvas?.getObjects()
+      if (objects) canvas1.canvas?.remove(objects[objects.length - 1])
 
       ws.send(
         JSON.stringify({

--- a/src/components/draw/DrawingPaper.vue
+++ b/src/components/draw/DrawingPaper.vue
@@ -118,7 +118,7 @@ export default defineComponent({
         canvas1.canvas?.clear()
         redoStack.value?.empty()
 
-        var objects = canvas1.canvas?.getObjects()
+        let objects = canvas1.canvas?.getObjects()
         if (objects) {
           undoStack.value.push(objects[objects.length - 1])
         }
@@ -180,7 +180,7 @@ export default defineComponent({
       if (redoStack.value?.count) {
         if (redoStack.value.peek() == undefined) {
           canvas1.canvas?.clear()
-          var objects = canvas1.canvas?.getObjects()
+          let objects = canvas1.canvas?.getObjects()
           if (objects) {
             redoStack.value.pop()
             undoStack.value?.push(objects[objects.length - 1])
@@ -242,7 +242,7 @@ export default defineComponent({
           })
           canvas1.canvas?.add(path)
 
-          var objects = canvas1.canvas?.getObjects()
+          let objects = canvas1.canvas?.getObjects()
           if (objects) {
             undoStack.value?.push(objects[objects.length - 1])
             redoStack.value?.empty()
@@ -279,7 +279,7 @@ export default defineComponent({
         fill: false
       }
 
-      var objects = canvas1.canvas?.getObjects()
+      let objects = canvas1.canvas?.getObjects()
       if (objects) waitDraw(objects, drawInstruction)
     }
 

--- a/src/components/draw/PencilCase.vue
+++ b/src/components/draw/PencilCase.vue
@@ -43,42 +43,52 @@
     />
 
     <button
-      @click="selectClear"
+      v-for="(operationIcon, index) in operationIcons"
+      :key="index"
+      @click="operationIcon.method"
       class="border-0 d-flex align-items-center justify-content-center pen_button"
       type="button"
     >
-      <i class="fas fa-undo"></i>
+      <i :class="[operationIcon.icon, operationIcon.opacity]" class="fas"></i>
     </button>
   </div>
 </template>
 
 <script lang="ts">
-import { defineComponent, reactive, ref, toRef, PropType } from 'vue'
+import { defineComponent, reactive, ref, toRef, PropType, computed } from 'vue'
 import { PencilCaseSetting } from '../../interface/pencilCaseSetting'
+import { Stack } from '../../model/stack'
 
 export default defineComponent({
   name: 'pencilCase',
-  props: { pencilCaseSettings: Object as PropType<PencilCaseSetting> },
+  props: {
+    pencilCaseSettings: Object as PropType<PencilCaseSetting>,
+    undoStack: Stack,
+    redoStack: Stack
+  },
   emits: [
     'selectPen',
     'selectEraser',
     'selectClear',
+    'selectUndo',
+    'selectRedo',
     'selectColor',
     'rangeBold'
   ],
   setup(props, { emit }) {
     let pencilCaseSetting = toRef(props, 'pencilCaseSettings')
     let colorPalette = ref<HTMLInputElement>()
-    const selectPen = () => {
-      emit('selectPen')
-    }
-    const selectEraser = () => {
-      emit('selectEraser')
-    }
+    let undoStack = toRef(props, 'undoStack')
+    let redoStack = toRef(props, 'redoStack')
+    const selectPen = () => emit('selectPen')
 
-    const selectClear = () => {
-      emit('selectClear')
-    }
+    const selectEraser = () => emit('selectEraser')
+
+    const selectClear = () => emit('selectClear')
+
+    const selectUndo = () => emit('selectUndo')
+
+    const selectRedo = () => emit('selectRedo')
 
     const selectColor = () => {
       if (pencilCaseSetting.value) {
@@ -87,9 +97,7 @@ export default defineComponent({
       emit('selectColor', String(colorPalette?.value?.value))
     }
 
-    const rangeBold = () => {
-      emit('rangeBold')
-    }
+    const rangeBold = () => emit('rangeBold')
 
     let penIcons = reactive([
       {
@@ -106,14 +114,45 @@ export default defineComponent({
 
     let penSizes = ref(['solid 1px #000', 'solid 2px #000', 'solid 3px #000'])
 
+    const undoOpacity = computed(() => {
+      return undoStack.value?.count == 0 ? 'opacity-50' : 'opacity-100'
+    })
+
+    const redoOpacity = computed(() => {
+      return redoStack.value?.count == 0 ? 'opacity-50' : 'opacity-100'
+    })
+
+    const trashOpacity = computed(() => 'opacity-100')
+
+    let operationIcons = reactive([
+      {
+        icon: 'fa-undo',
+        method: selectUndo,
+        opacity: undoOpacity
+      },
+      {
+        icon: 'fa-redo',
+        method: selectRedo,
+        opacity: redoOpacity
+      },
+      {
+        icon: 'fa-trash-alt',
+        method: selectClear,
+        opacity: trashOpacity
+      }
+    ])
+
     return {
       pencilCaseSetting,
       penIcons,
       penSizes,
       colorPalette,
+      operationIcons,
       selectPen,
       selectEraser,
       selectClear,
+      selectUndo,
+      selectRedo,
       selectColor,
       rangeBold
     }

--- a/src/components/screen/Chat.vue
+++ b/src/components/screen/Chat.vue
@@ -49,7 +49,7 @@ export default defineComponent({
     const userAnswer = ref<string>('')
 
     const ws: WebSocket = new WebSocket(
-      (window.location.protocol == 'https' ? 'wss' : 'wss') +
+      (window.location.protocol == 'https:' ? 'wss' : 'ws') +
         '://' +
         process.env.VUE_APP_BACKEND_URL +
         'ws/chat' +

--- a/src/model/node.ts
+++ b/src/model/node.ts
@@ -1,0 +1,8 @@
+export class Node {
+  public data: fabric.Object | null
+  public next: Node | null
+  constructor(data: fabric.Object | null) {
+    this.data = data
+    this.next = null
+  }
+}

--- a/src/model/stack.ts
+++ b/src/model/stack.ts
@@ -1,0 +1,38 @@
+import { Node } from './node'
+export class Stack {
+  public head: Node | null
+  public count: number
+  constructor() {
+    this.head = null
+    this.count = 0
+  }
+
+  public Stack(): void {
+    this.head = null
+  }
+
+  public push(data: fabric.Object | null): void {
+    const temp: Node | null = this.head
+    this.head = new Node(data)
+    this.head.next = temp
+    this.count++
+  }
+
+  public pop(): fabric.Object | null {
+    if (this.head == null) return null
+    const temp: Node | null = this.head
+    this.head = this.head.next
+    this.count--
+    return temp.data
+  }
+
+  public peek(): fabric.Object | null {
+    if (this.head == null) return null
+    return this.head.data
+  }
+
+  public empty(): void {
+    this.head = null
+    this.count = 0
+  }
+}

--- a/src/views/Room.vue
+++ b/src/views/Room.vue
@@ -23,15 +23,24 @@
         <div
           class="d-flex flex-nowrap flex-column col-lg-8 col-11 pe-lg-3 px-0"
         >
-          <DrawingPaper :pencilCaseSettings="pencilCaseSettings" ref="canvas" />
+          <DrawingPaper
+            :pencilCaseSettings="pencilCaseSettings"
+            :undoStack="undoStack"
+            :redoStack="redoStack"
+            ref="canvas"
+          />
 
           <div class="order-3 order-lg-2 btn-wrapper">
             <div class="py-1 mx-auto">
               <PencilCase
                 :pencilCaseSettings="pencilCaseSettings"
+                :undoStack="undoStack"
+                :redoStack="redoStack"
                 @selectPen="selectPen"
                 @selectEraser="selectEraser"
                 @selectClear="selectClear"
+                @selectUndo="selectUndo"
+                @selectRedo="selectRedo"
                 @selectColor="selectColor"
                 @rangeBold="rangeBold"
               />
@@ -81,6 +90,7 @@ import Chat from '../components/screen/Chat.vue'
 import { Player } from '../model/player'
 import { User } from '../model/user'
 import { HitPictureRoom } from '../model/hitPictureRoom'
+import { Stack } from '../model/stack'
 import { PencilCaseSetting } from '../interface/pencilCaseSetting'
 
 export default defineComponent({
@@ -115,6 +125,9 @@ export default defineComponent({
       eraserBold: 10
     })
 
+    let undoStack: Stack = reactive(new Stack())
+    let redoStack: Stack = reactive(new Stack())
+
     const selectPen = () => {
       if (canvas.value) canvas.value.pen()
     }
@@ -125,6 +138,14 @@ export default defineComponent({
 
     const selectClear = () => {
       if (canvas.value) canvas.value.clear()
+    }
+
+    const selectUndo = () => {
+      if (canvas.value) canvas.value.undo()
+    }
+
+    const selectRedo = () => {
+      if (canvas.value) canvas.value.redo()
     }
 
     const selectColor = (color: string) => {
@@ -142,10 +163,14 @@ export default defineComponent({
       user2,
       pencilCaseSettings,
       canvas,
+      undoStack,
+      redoStack,
       addUser,
       selectPen,
       selectEraser,
       selectClear,
+      selectUndo,
+      selectRedo,
       selectColor,
       rangeBold
     }

--- a/src/views/Room.vue
+++ b/src/views/Room.vue
@@ -137,15 +137,15 @@ export default defineComponent({
     }
 
     const selectClear = () => {
-      if (canvas.value) canvas.value.clear()
+      if (canvas.value) canvas.value.sendClear()
     }
 
     const selectUndo = () => {
-      if (canvas.value) canvas.value.undo()
+      if (canvas.value) canvas.value.sendUndo()
     }
 
     const selectRedo = () => {
-      if (canvas.value) canvas.value.redo()
+      if (canvas.value) canvas.value.sendRedo()
     }
 
     const selectColor = (color: string) => {


### PR DESCRIPTION
# 概要
- redo、undoの実装
- 筆箱で、redo、undoできるか判断できるようにした
- webSocketでredo、undo、clear実装

## 問題点
描き手が書いた時、player全員のstackが同じになるよう、書いた線(object)を削除している
await、asyncでapi処理を待って削除しているが、多少のラグがあり削除が速い

https://user-images.githubusercontent.com/68400191/153626812-ea353008-017e-4f8f-beec-543b3d3091f1.mov


